### PR TITLE
Add Primary and Secondary Buttons

### DIFF
--- a/src/components/TuxComponents/elements/Buttons.js
+++ b/src/components/TuxComponents/elements/Buttons.js
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { disable_btn, enable_btn, enable_hover, google_hover, disable_g_btn, g_focus } from '../utilities/Colors';
+import { primary_default, disable_btn, enable_btn, enable_hover, google_hover, disable_g_btn, g_focus, primary_text, primary_hover, pressed_btn, secondary_default, secondary_hover } from '../utilities/Colors';
 import {
   btn_active_shadow,
   input_border,
@@ -11,13 +11,137 @@ import {
   FlexCenter,
 } from "../utilities";
 
-// export const Primary = styled.button`
+// Primary Button
+export const PrimaryButton = styled.button`
+  width: 280px;
+  height: 50px;
+  border: none;
+  border-radius: 5px;
+  background: ${primary_default};
+  padding: 12px 0;
+  margin: 17px 8px;
+  color: ${primary_text};
+  font: 700 20px "Poppins", sans-serif;
+  cursor: pointer;
+  &:hover {
+    background: ${primary_hover};
+  }
+  &:active {
+    background: ${pressed_btn};
+    color: white;
+  }
+  // Focus
+  ${(props) =>
+    props.focus &&
+    css`
+      background-color: ${primary_default};
+      &:hover {
+        background-color: ${primary_hover};
+      }
+  `}
+  // Hover
+  ${(props) =>
+    props.hover &&
+    css`
+      background-color: ${primary_hover};
+      &:hover {
+        background-color: ${primary_hover};
+      }
+  `}
+  // Diasbled
+    ${(props) =>
+    props.disabled &&
+    css`
+      background-color: ${disable_btn};
+      &:hover {
+        background-color: ${disable_btn};
+      }
+    `}
+  // Depressed
+    ${(props) =>
+    props.depressed &&
+    css`
+      background-color: ${pressed_btn};
+      color: white;
+    `}
+    // Large
+    ${(props) =>
+    props.large &&
+    css`
+      width: 343px;
+    `}
+    // Small
+    ${(props) =>
+    props.small &&
+    css`
+      width: 154px;
+    `}
+`;
 
-// `;
-
-// export const Secondary = styled.button`
-
-// `;
+// Secondary Button
+export const SecondaryButton = styled.button`
+  width: 280px;
+  height: 50px;
+  border: none;
+  border-radius: 5px;
+  background: ${secondary_default};
+  padding: 12px 0;
+  margin: 17px 8px;
+  color: white;
+  font: 700 20px "Poppins", sans-serif;
+  cursor: pointer;
+  &:hover {
+    background: ${secondary_hover};
+  }
+  &:active {
+    background: ${pressed_btn};
+  }
+  // Focus
+  ${(props) =>
+    props.focus &&
+    css`
+      background-color: ${secondary_default};
+      &:hover {
+        background-color: ${secondary_hover};
+      }
+  `}
+    // Hover
+    ${(props) =>
+    props.hover &&
+    css`
+      background-color: ${secondary_hover};
+      &:hover {
+        background-color: ${secondary_hover};
+      }
+  `}
+  // Diasbled
+    ${(props) =>
+    props.disabled &&
+    css`
+      background-color: ${disable_btn};
+      &:hover {
+        background-color: ${disable_btn};
+      }
+    `}
+  // Depressed
+    ${(props) =>
+    props.depressed &&
+    css`
+      background-color: ${pressed_btn};
+    `}
+    // Large
+    ${(props) =>
+    props.large &&
+    css`
+      width: 343px;
+    `}
+    // Small
+    ${(props) =>
+    props.small &&
+    css`
+      width: 154px;
+    `}
+`;
 
 export const GoogleG = styled.img`
   width: 35px;

--- a/src/components/TuxComponents/elements/Buttons.stories.js
+++ b/src/components/TuxComponents/elements/Buttons.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button280, Button350, LoginBtn, MedBtn, DisabledBtn, Button, GoogleBox, GoogleG  } from "./Buttons";
+import { Button280, Button350, LoginBtn, MedBtn, DisabledBtn, Button, GoogleBox, GoogleG, PrimaryButton, SecondaryButton  } from "./Buttons";
 import { withDesign } from "storybook-addon-designs";
 
 export default {
@@ -10,6 +10,8 @@ export default {
 
 export const AllButtons = () => (
   <>
+   <PrimaryButton>Primary</ PrimaryButton>
+    <SecondaryButton>Secondary</SecondaryButton>
     <GoogleBox>
         <GoogleG src='/images/google_logo.png' />
         Sign with Google
@@ -79,6 +81,43 @@ Google.story = {
         "https://www.figma.com/file/WKazrI05IMxIcso2Cn5obC/Tux-Design-Library?node-id=1012%3A0",
     },
   },
+};
+
+export const Primary = (args) => (
+  <PrimaryButton {...args}>Primary</ PrimaryButton>
+);
+Primary.args = {
+  depressed: false,
+  focus: false,
+  hover: false,
+  small: false,
+  large: false,
+};
+Primary.story = {
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/WKazrI05IMxIcso2Cn5obC/Tux-Design-Library?node-id=1424%3A0",
+    }
+  }
+};
+export const Secondary = (args) => (
+  <SecondaryButton {...args}>Secondary</ SecondaryButton>
+);
+Secondary.args = {
+  depressed: false,
+  focus: false,
+  hover: false,
+  small: false,
+  large: false,
+};
+Secondary.story = {
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/WKazrI05IMxIcso2Cn5obC/Tux-Design-Library?node-id=1424%3A0",
+    }
+  }
 };
 
 

--- a/src/components/TuxComponents/utilities/Colors.js
+++ b/src/components/TuxComponents/utilities/Colors.js
@@ -14,18 +14,32 @@ export const present_text = "#1B9BA0";
 export const future_text = "#999999";
 export const text_black = "#000";
 export const text_white = "#fff";
-// Button Element Colors
-//default button color
+
+// ********* Button Element Colors *********
+
+export const disable_btn = "#ccc";
+export const pressed_btn = '#1C3C3B';
+// Primary Button Colors
+// Default and Focus colors are the same
+export const primary_default = '#78d6da';
+export const primary_hover = '#C2ECEE';
+export const primary_text = '#274D4F';
+// Secondary Button Colors
+export const secondary_default = '#3c8582';
+export const secondary_hover = '#6da4a1';
+
+
+// TODO: remove enable_btn, enable_hover, default_focus, and default_depressed once all instances of default button are removed and replaced with Secondary button
 export const enable_btn = "#3c8582";
 export const enable_hover = "#236c69";
-export const google_hover = "#E5E5E5";
-//default focus color
 export const default_focus = "#1C3C3B";
-export const g_focus = "#4285F4";
-export const disable_btn = "#ccc";
-export const disable_g_btn = "#D3D3D3";
-// default depressed color
 export const default_depressed = "#6DA4A1";
+
+export const google_hover = "#E5E5E5";
+export const g_focus = "#4285F4";
+export const disable_g_btn = "#D3D3D3";
+
+
 // Input Colors
 export const background_input = "#eee";
 // Other Colors


### PR DESCRIPTION
Add Primary and Secondary buttons from Figma file. Includes hover, focus, depressed, and disabled states. Add both buttons to Storybook